### PR TITLE
Update the Locale method calls to match the new API.

### DIFF
--- a/load.py
+++ b/load.py
@@ -141,7 +141,7 @@ class HourlyIncome(object):
         :param msg:
         :return:
         """
-        msg = "{} Visits/hr".format(Locale.stringFromNumber(self.rate(), 2))
+        msg = "{} Visits/hr".format(Locale.string_from_number(self.rate(), 2))
         self.rate_widget.after(0, self.rate_widget.config, {"text": msg})
 
     def update_hourlyincome(self):
@@ -150,7 +150,7 @@ class HourlyIncome(object):
         :param msg:
         :return:
         """
-        msg = "{} Cr/hr".format(Locale.stringFromNumber(self.speed(), 2))
+        msg = "{} Cr/hr".format(Locale.string_from_number(self.speed(), 2))
         self.speed_widget.after(0, self.speed_widget.config, {"text": msg})
 
     def update_earned(self):
@@ -159,7 +159,7 @@ class HourlyIncome(object):
         :param msg:
         :return:
         """
-        msg = "{} Cr".format(Locale.stringFromNumber(self.trip_earnings() + self.saved_earnings, 2))
+        msg = "{} Cr".format(Locale.string_from_number(self.trip_earnings() + self.saved_earnings, 2))
         self.earned_widget.after(0, self.earned_widget.config, {"text": msg})
 
 


### PR DESCRIPTION
Within the `l10n.Locale` module, the `stringFromNumber` method has been updated from camelCase to snake_case, and is now called `string_from_number`. This breaking change was making the plugin fail to load.

Updated the `Locale` method calls to accommodate for breaking change in the API.